### PR TITLE
Fix ignore patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## `jupyter_starters 0.1.0a2`
+
+- add ignore patterns to schema
+- fix default ignore patterns
+
+## `@deathbeds/jupyterlab-starters 0.1.0a2`
+
+- add glob ignore patterns to schema
+
 ## `jupyter_starters 0.1.0a1`
 
 - add more sources of config

--- a/atest/02_Simple.robot
+++ b/atest/02_Simple.robot
@@ -20,3 +20,12 @@ Simple Folder
     Wait Until Created    ${HOME}${/}whitepaper-multiple
     Wait Until Page Contains Element    ${XP FILE TREE ITEM}\[contains(text(), '00 Introduction.ipynb')]
     Capture Page Screenshot    folder.png
+
+Folder Ignoring
+    [Documentation]    Will it ignore paths?
+    Create File    ..${/}examples${/}whitepaper-multiple${/}node_modules${/}foo.txt
+    Click Element    ${CSS LAUNCH CARD FOLDER}
+    Wait Until Created    ${HOME}${/}whitepaper-multiple
+    Wait Until Page Contains Element    ${XP FILE TREE ITEM}\[contains(text(), '00 Introduction.ipynb')]
+    Page Should Not Contain Element    ${XP FILE TREE ITEM}\[contains(text(), 'node_modules')]
+    Capture Page Screenshot    ignored.png

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,8 @@ variables:
   PYTHONUNBUFFERED: 1
   ATEST_RETRIES: 2
 
-  PY_JLST_VERSION: 0.1.0a1
-  JS_JLST_VERSION: 0.1.0-a0
+  PY_JLST_VERSION: 0.1.0a2
+  JS_JLST_VERSION: 0.1.0-a2
 
   FIRST_PARTY_LABEXTENSIONS: >-
     packages/jupyterlab-starters/deathbeds-jupyterlab-starters-$(JS_JLST_VERSION).tgz

--- a/packages/jupyterlab-starters/package.json
+++ b/packages/jupyterlab-starters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deathbeds/jupyterlab-starters",
-  "version": "0.1.0a0",
+  "version": "0.1.0a2",
   "description": "Parameterized files and folders for JupyterLab",
   "keywords": [
     "jupyter",

--- a/src/jupyter_starters/_version.py
+++ b/src/jupyter_starters/_version.py
@@ -1,3 +1,3 @@
 """ single source of truth for jupyter_starters version
 """
-__version__ = "0.1.0a1"
+__version__ = "0.1.0a2"

--- a/src/jupyter_starters/schema/v1.json
+++ b/src/jupyter_starters/schema/v1.json
@@ -100,6 +100,11 @@
             "$ref": "#/definitions/command"
           }
         },
+        "ignore": {
+          "description": "glob patterns to ignore (will also ignore children)",
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "schema": {
           "description": "JSON schema for a body to pass",
           "type": "object",


### PR DESCRIPTION
## References

> Apparently can't create any kind of issues right now?

## Code changes

Ignore patterns were checking against the full URI, which broke in some (many) settings. This adopts `src`-relative default patterns, and adds them to the schema as a list.

## User-facing changes

Will copy files from more places.

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [x] documented
- [x] changelog entry
