### PR TITLE
add rudimentary markdown for descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## `@deathbeds/jupyterlab-starters 0.2.0a0`
 
 - add notebook metadata authoring [#13][]
+- render markdown inside schema descriptions [#16][]
 
 ## `jupyter_starters 0.1.0a3`
 
@@ -34,3 +35,4 @@
 - initial implementation
 
 [#13]: https://github.com/deathbeds/jupyterlab-starters/pull/13
+[#16]: https://github.com/deathbeds/jupyterlab-starters/pull/16

--- a/examples/Starter Notebook.ipynb
+++ b/examples/Starter Notebook.ipynb
@@ -242,7 +242,7 @@
     "schema": {
      "properties": {
       "name": {
-       "description": "What is your name?",
+       "description": "What is **your** name?",
        "title": "Name",
        "type": "string"
       }

--- a/jupyter_notebook_config.json
+++ b/jupyter_notebook_config.json
@@ -46,7 +46,7 @@
           "properties": {
             "dest": {
               "title": "Topic",
-              "description": "the topic of the whitepaper",
+              "description": "the *topic* of the whitepaper",
               "type": "string",
               "default": "Unimagined"
             }

--- a/packages/jupyterlab-starters/package.json
+++ b/packages/jupyterlab-starters/package.json
@@ -38,17 +38,20 @@
   "peerDependencies": {
     "@jupyterlab/application": "1",
     "@jupyterlab/launcher": "1",
-    "@jupyterlab/notebook": "1"
+    "@jupyterlab/notebook": "1",
+    "marked": "*"
   },
   "devDependencies": {
     "@types/react-jsonschema-form": "^1.6.6",
+    "@types/marked": "^0.7.0",
     "@jupyterlab/application": "1",
     "@jupyterlab/launcher": "1",
     "@jupyterlab/notebook": "1",
     "json-schema-to-typescript": "^8.0.0",
     "react": "*",
     "rimraf": "~2.6.2",
-    "typescript": "~3.7.2"
+    "typescript": "~3.7.2",
+    "marked": "^0.7.0"
   },
   "jupyterlab": {
     "discovery": {

--- a/packages/jupyterlab-starters/src/widgets/builder/index.tsx
+++ b/packages/jupyterlab-starters/src/widgets/builder/index.tsx
@@ -7,6 +7,7 @@ import { IStartContext } from '../../tokens';
 import { CSS } from '../../css';
 
 import { SchemaForm } from '../schemaform';
+import { MarkdownDescriptionField } from '../form/fields/markdowndescription';
 
 import { BuilderModel } from './model';
 
@@ -33,7 +34,10 @@ export class BodyBuilder extends Widget {
     this._form = new SchemaForm(this._context.starter.schema, {
       liveValidate: true,
       formData: this._context.body,
-      uiSchema: this._context.starter.uiSchema || {}
+      uiSchema: this._context.starter.uiSchema || {},
+      fields: {
+        DescriptionField: MarkdownDescriptionField
+      }
     });
     this._buttons = this.makeButtons();
 

--- a/packages/jupyterlab-starters/src/widgets/form/fields/markdowndescription/index.tsx
+++ b/packages/jupyterlab-starters/src/widgets/form/fields/markdowndescription/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import marked from 'marked';
+
+import { defaultSanitizer } from '@jupyterlab/apputils';
+
+export class MarkdownDescriptionField extends React.Component<any, any, any> {
+  render() {
+    const { id, description } = this.props;
+
+    if (!description) {
+      return null;
+    }
+
+    return (
+      <div
+        id={id}
+        className="field-description jp-RenderedHTMLCommon jp-RenderedMarkdown"
+        dangerouslySetInnerHTML={{
+          __html: defaultSanitizer
+            .sanitize(marked(description))
+            .replace(/<a /g, '<a target="_blank" rel="noreferrer" ')
+        }}
+      ></div>
+    );
+  }
+}

--- a/packages/jupyterlab-starters/src/widgets/form/fields/rawjson/index.tsx
+++ b/packages/jupyterlab-starters/src/widgets/form/fields/rawjson/index.tsx
@@ -14,7 +14,8 @@ export class RawJSONObjectField extends ObjectField {
       registry = rjsfUtils.getDefaultRegistry()
     } = this.props;
 
-    const { definitions } = registry;
+    const { definitions, fields } = registry;
+    const { TitleField, DescriptionField } = fields;
     const schema = (rjsfUtils as any).retrieveSchema(
       this.props.schema,
       definitions,
@@ -40,16 +41,26 @@ export class RawJSONObjectField extends ObjectField {
     };
 
     return (
-      <div>
-        <legend>{title}</legend>
-        <p className="field-description">{description}</p>
+      <>
+        <TitleField
+          id={`${idSchema.$id}__title`}
+          title={title}
+          required={this.props.required}
+          formContext={this.props.formContext}
+        />
+        <DescriptionField
+          id={`${this.props.idSchema.$id}__description`}
+          description={description}
+          formContext={this.props.formContext}
+        />
         <textarea
           spellCheck={false}
           id={idSchema.$id}
+          className="form-control"
           defaultValue={JSON.stringify(formData, null, 2)}
           onChange={onChange}
         ></textarea>
-      </div>
+      </>
     );
   }
 }

--- a/packages/jupyterlab-starters/src/widgets/meta/index.ts
+++ b/packages/jupyterlab-starters/src/widgets/meta/index.ts
@@ -4,7 +4,8 @@ import { Widget, BoxLayout } from '@phosphor/widgets';
 import { CSS } from '../../css';
 import { SchemaForm } from '../schemaform';
 import { PreviewCard } from '../previewcard';
-import { RawJSONObjectField } from '../rawjson';
+import { RawJSONObjectField } from '../form/fields/rawjson';
+import { MarkdownDescriptionField } from '../form/fields/markdowndescription';
 
 import { NotebookMetadataModel } from './model';
 
@@ -39,7 +40,8 @@ export class NotebookMetadata extends Widget {
         }
       },
       fields: {
-        jsonobject: RawJSONObjectField
+        jsonobject: RawJSONObjectField,
+        DescriptionField: MarkdownDescriptionField
       }
     });
     this.model.form = this._form.model;

--- a/packages/jupyterlab-starters/style/form/core.css
+++ b/packages/jupyterlab-starters/style/form/core.css
@@ -20,7 +20,7 @@
 
 .jp-SchemaForm fieldset fieldset {
   padding-left: var(--jp-notebook-padding);
-  border-left: solid 1px var(--jp-border-color0);
+  border-left: solid 4px var(--jp-border-color3);
 }
 
 .jp-SchemaForm button[type='submit'] {
@@ -40,6 +40,8 @@
   margin-bottom: var(--jp-ui-font-size1);
   width: 100%;
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .jp-SchemaForm .form-group:last-child {
@@ -47,9 +49,8 @@
 }
 
 .jp-SchemaForm .field-description {
-  font-style: italic;
-  margin-bottom: calc(var(--jp-ui-font-size1) / 2);
   color: var(--jp-ui-font-color2);
+  order: 2;
 }
 
 .jp-SchemaForm .required {

--- a/packages/jupyterlab-starters/style/index.css
+++ b/packages/jupyterlab-starters/style/index.css
@@ -34,7 +34,7 @@
 }
 
 .jp-Starters-NotebookMetadata {
-  min-width: 300px;
+  min-width: 350px;
 }
 
 .jp-Starters-BodyBuilder-buttons {
@@ -81,4 +81,8 @@
 
 .jp-Starters-FormPanel .jp-SchemaForm > .form-group {
   margin-bottom: 20rem;
+}
+
+.jp-Starters-FormPanel .jp-RenderedHTMLCommon {
+  padding: 0;
 }

--- a/src/jupyter_starters/schema/v2.json
+++ b/src/jupyter_starters/schema/v2.json
@@ -107,12 +107,12 @@
         },
         "icon": {
           "title": "Icon",
-          "description": "an SVG to use in Launcher cards and tab icons",
+          "description": "[SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) string to use in Launcher cards and tab icons",
           "type": "string"
         },
         "commands": {
           "title": "Commands",
-          "description": "JupyterLab commands to run after the Starter has completed",
+          "description": "[JupyterLab commands](https://jupyterlab.readthedocs.io/en/stable/developer/extension_points.html#commands) to run after the Starter has completed",
           "type": "array",
           "items": {
             "$ref": "#/definitions/command"
@@ -120,7 +120,7 @@
         },
         "ignore": {
           "title": "Ignore Files",
-          "description": "Folders and files exclude from copying, with * for wildcards",
+          "description": "[glob-style patterns](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.match) for folders and files exclude from copying, with * for wildcards",
           "type": "array",
           "items": {
             "type": "string"
@@ -128,20 +128,19 @@
         },
         "schema": {
           "title": "JSON Schema",
-          "description": "JSON schema the body must validate against before continuing",
+          "description": "[Draft 7 JSON Schema](https://json-schema.org/understanding-json-schema) that generates a form like this one, which must validate the user's data. Description fields may include markdown",
           "type": "object",
           "$ref": "#/definitions/json-schema"
         },
         "uiSchema": {
           "title": "UI Schema",
-          "description": "A react-jsonschema-form UI schema for customizing the selection of widgets https://react-jsonschema-form.readthedocs.io/en/latest/form-customization/#the-uischema-object",
+          "description": "[react-jsonschema-form `uiSchema`](https://react-jsonschema-form.readthedocs.io/en/latest/form-customization/#the-uischema-object) for customizing the selection of widgets",
           "type": "object"
         }
       }
     },
     "json-schema": {
       "title": "JSON Schema",
-      "description": "presently under-defined because of toolchain",
       "type": "object"
     },
     "command": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,6 +1356,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/marked@^0.7.0":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.7.2.tgz#1393f076773b55cc7078c0fbeb86a497c69db97e"
+  integrity sha512-A3EDyNaq6OCcpaOia2HQ/tu2QYt8DKuj4ExP21VU3cU3HTo2FLslvbqa2T1vux910RHvuSVqpwKnnykSFcRWOA==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
## References

- fixes #11

## Code changes

Adds a `MarkdownDescriptionField` used by both the main starter schema form and the notebook metadata editor. Doesn't work with MathJax, as there's no real node for mathjax to hack on. Gfm probably works.

## User-facing changes

Now can include links, etc. in descriptions.

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [x] changelog entry
