### PR TITLE
Add title/description/help Jupyter Markdown via mimerenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## `@deathbeds/jupyterlab-starters 0.2.0a0`
 
 - add notebook metadata authoring [#13][]
+- add Jupyter markdown to `title` and `description` in forms [#17][]
 
 ## `jupyter_starters 0.1.0a3`
 
@@ -34,3 +35,4 @@
 - initial implementation
 
 [#13]: https://github.com/deathbeds/jupyterlab-starters/pull/13
+[#17]: https://github.com/deathbeds/jupyterlab-starters/pull/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## `@deathbeds/jupyterlab-starters 0.2.0a0`
 
 - add notebook metadata authoring [#13][]
-- add Jupyter markdown to `title` and `description` in forms [#17][]
+- add Jupyter markdown to `title`, `description` and `ui:help` in schema forms [#17][]
 
 ## `jupyter_starters 0.1.0a3`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Try out some stuff. Make some whitepapers and cookiecutters.
 anaconda-project run atest
 ```
 
-> _You have to run against a "clean" lab, e.g. `postBuild`_
+> _You have to run against a "clean" lab, e.g. `apr postBuild`_
 
 ## hacking
 

--- a/atest/03_Parameters.robot
+++ b/atest/03_Parameters.robot
@@ -6,7 +6,7 @@ Resource          Keywords.robot
 Library           String
 
 *** Variables ***
-${CSS TOPIC}      css:input[label="Topic"]
+${CSS TOPIC}      css:input[label="## Topic"]
 
 *** Test Cases ***
 Cancel
@@ -23,6 +23,7 @@ Parameter Notebook
     Click Element    ${CSS LAUNCH CARD PARAM}
     ${topic} =    Generate Random String
     Really Input Text    ${CSS TOPIC}    ${topic}
+    Starter Form Should Contain Markdown Elements
     Advance Starter Form
     Wait Until Page Contains Element    ${XP FILE TREE ITEM}\[contains(text(), '${topic} Whitepaper.ipynb')]
     Wait Until Kernel
@@ -30,3 +31,13 @@ Parameter Notebook
     Wait Until Page Contains Element    id:My-Next-Big-Idea
     Save Notebook
     Capture Page Screenshot    11-notebook-did-save.png
+
+*** Keywords ***
+Starter Form Should Contain Markdown Elements
+    [Documentation]    Verify some fancy markdown rendered.
+    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.legend h1
+    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.control-label h2
+    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.field-description em
+    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.field-description blockquote a
+    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.help-block code
+    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.help-block .MathJax

--- a/atest/03_Parameters.robot
+++ b/atest/03_Parameters.robot
@@ -23,21 +23,22 @@ Parameter Notebook
     Click Element    ${CSS LAUNCH CARD PARAM}
     ${topic} =    Generate Random String
     Really Input Text    ${CSS TOPIC}    ${topic}
+    Capture Page Screenshot    10-notebook-topic-changed.png
     Starter Form Should Contain Markdown Elements
     Advance Starter Form
     Wait Until Page Contains Element    ${XP FILE TREE ITEM}\[contains(text(), '${topic} Whitepaper.ipynb')]
     Wait Until Kernel
-    Capture Page Screenshot    10-notebook-accepted-parameter.png
+    Capture Page Screenshot    11-notebook-accepted-parameter.png
     Wait Until Page Contains Element    id:My-Next-Big-Idea
     Save Notebook
-    Capture Page Screenshot    11-notebook-did-save.png
+    Capture Page Screenshot    12-notebook-did-save.png
 
 *** Keywords ***
 Starter Form Should Contain Markdown Elements
     [Documentation]    Verify some fancy markdown rendered.
-    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.legend h1
-    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.control-label h2
-    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.field-description em
-    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.field-description blockquote a
-    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.help-block code
-    Page Should Contain Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.help-block .MathJax
+    Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.legend h1
+    Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.control-label h2
+    Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.field-description em
+    Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.field-description blockquote a
+    Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.help-block code
+    Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.help-block .MathJax

--- a/atest/03_Parameters.robot
+++ b/atest/03_Parameters.robot
@@ -36,7 +36,7 @@ Parameter Notebook
 *** Keywords ***
 Starter Form Should Contain Markdown Elements
     [Documentation]    Verify some fancy markdown rendered.
-    Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.legend h1
+    Wait Until Page Contains Element    ${CSS BODYBUILDER} legend.jp-RenderedMarkdown h1
     Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.control-label h2
     Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.field-description em
     Wait Until Page Contains Element    ${CSS BODYBUILDER} .jp-RenderedMarkdown.field-description blockquote a

--- a/jupyter_notebook_config.json
+++ b/jupyter_notebook_config.json
@@ -40,7 +40,7 @@
         "icon": "<svg><g class='jp-icon-contrast3' fill='#ccc'><rect width='100' height='100'/></g></svg>",
         "uiSchema": {
           "dest": {
-            "ui:help": "keep it short and simple it will go in: $1$ file named: `<topic> Whitepaper.ipynb`",
+            "ui:help": "keep it short and simple: it will go in $1$ file named: `<topic> Whitepaper.ipynb`",
             "ui:autofocus": true
           }
         },

--- a/jupyter_notebook_config.json
+++ b/jupyter_notebook_config.json
@@ -38,15 +38,21 @@
         "src": "examples/whitepaper-single.ipynb",
         "dest": "{% now 'local' %} {{ dest }} Whitepaper.ipynb",
         "icon": "<svg><g class='jp-icon-contrast3' fill='#ccc'><rect width='100' height='100'/></g></svg>",
+        "uiSchema": {
+          "dest": {
+            "ui:help": "keep it short and simple it will go in: $1$ file named: `<topic> Whitepaper.ipynb`",
+            "ui:autofocus": true
+          }
+        },
         "schema": {
-          "title": "A Named whitepaper",
-          "description": "A whitepaper that already has a name",
+          "title": "# A Named whitepaper",
+          "description": "> A whitepaper that already has a name, based on the [Heilmeier Catechism](https://www.darpa.mil/work-with-us/heilmeier-catechism).",
           "type": "object",
           "required": ["dest"],
           "properties": {
             "dest": {
-              "title": "Topic",
-              "description": "the topic of the whitepaper",
+              "title": "## Topic",
+              "description": "the _topic_ of the whitepaper",
               "type": "string",
               "default": "Unimagined"
             }

--- a/packages/jupyterlab-starters/src/manager.ts
+++ b/packages/jupyterlab-starters/src/manager.ts
@@ -3,15 +3,17 @@ import { Signal } from '@phosphor/signaling';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
 import { IIconRegistry, IconRegistry } from '@jupyterlab/ui-components';
+import { IRenderMimeRegistry, RenderedMarkdown } from '@jupyterlab/rendermime';
+
 import {
   IStarterManager,
   DEFAULT_ICON_CLASS,
-  DEFAULT_ICON_NAME
+  DEFAULT_ICON_NAME,
+  API
 } from './tokens';
 
 import * as SCHEMA from './_schema';
 import { CSS } from './css';
-import { API } from './tokens';
 
 const { makeRequest, makeSettings } = ServerConnection;
 
@@ -20,9 +22,12 @@ export class StarterManager implements IStarterManager {
   private _starters: SCHEMA.Starters = {};
   private _serverSettings = makeSettings();
   private _icons: IIconRegistry;
+  private _rendermime: IRenderMimeRegistry;
+  private _markdown: RenderedMarkdown;
 
   constructor(options: IStarterManager.IOptions) {
     this._icons = options.icons;
+    this._rendermime = options.rendermime;
     this._changed = new Signal<IStarterManager, void>(this);
     const icon = { name: DEFAULT_ICON_NAME, svg: CSS.SVG.DEFAULT_ICON };
     const cookiecutter = {
@@ -30,6 +35,15 @@ export class StarterManager implements IStarterManager {
       svg: CSS.SVG.COOKIECUTTER
     };
     this._icons.addIcon(icon, cookiecutter);
+  }
+
+  get markdown() {
+    if (!this._markdown) {
+      this._markdown = this._rendermime.createRenderer(
+        'text/markdown'
+      ) as RenderedMarkdown;
+    }
+    return this._markdown;
   }
 
   get changed() {

--- a/packages/jupyterlab-starters/src/plugin.ts
+++ b/packages/jupyterlab-starters/src/plugin.ts
@@ -6,6 +6,7 @@ import {
 import { ILauncher } from '@jupyterlab/launcher';
 import { IIconRegistry } from '@jupyterlab/ui-components';
 import { MainAreaWidget } from '@jupyterlab/apputils';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 import { NotebookPanel, INotebookTracker } from '@jupyterlab/notebook';
 
@@ -29,17 +30,24 @@ import { BodyBuilder } from './widgets/builder';
 
 const plugin: JupyterFrontEndPlugin<void> = {
   id: `${NS}:plugin`,
-  requires: [ILabShell, ILauncher, IIconRegistry, INotebookTracker],
+  requires: [
+    ILabShell,
+    ILauncher,
+    IIconRegistry,
+    INotebookTracker,
+    IRenderMimeRegistry
+  ],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     shell: ILabShell,
     launcher: ILauncher,
     icons: IIconRegistry,
-    notebooks: INotebookTracker
+    notebooks: INotebookTracker,
+    rendermime: IRenderMimeRegistry
   ) => {
     const { commands } = app;
-    const manager: IStarterManager = new StarterManager({ icons });
+    const manager: IStarterManager = new StarterManager({ icons, rendermime });
 
     commands.addCommand(CommandIDs.start, {
       execute: async (args: any) => {

--- a/packages/jupyterlab-starters/src/tokens.ts
+++ b/packages/jupyterlab-starters/src/tokens.ts
@@ -1,7 +1,10 @@
 import { JSONObject } from '@phosphor/coreutils';
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
-import { IIconRegistry } from '@jupyterlab/ui-components';
 import { ISignal } from '@phosphor/signaling';
+
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { RenderedMarkdown } from '@jupyterlab/rendermime/lib/widgets';
+import { IIconRegistry } from '@jupyterlab/ui-components';
 
 import * as SCHEMA from './_schema';
 
@@ -17,6 +20,7 @@ export interface IStarterManager {
   starters: SCHEMA.Starters;
   starter(name: string): SCHEMA.Starter;
   iconClass(name: string, starter: SCHEMA.Starter): string;
+  markdown: RenderedMarkdown;
   fetch(): Promise<void>;
   start(
     name: string,
@@ -29,6 +33,7 @@ export interface IStarterManager {
 export namespace IStarterManager {
   export interface IOptions {
     icons: IIconRegistry;
+    rendermime: IRenderMimeRegistry;
   }
 }
 

--- a/packages/jupyterlab-starters/src/widgets/builder/index.tsx
+++ b/packages/jupyterlab-starters/src/widgets/builder/index.tsx
@@ -30,11 +30,16 @@ export class BodyBuilder extends Widget {
     this.title.label = label;
     this.title.iconClass = this.model.iconClass;
 
-    this._form = new SchemaForm(this._context.starter.schema, {
-      liveValidate: true,
-      formData: this._context.body,
-      uiSchema: this._context.starter.uiSchema || {}
-    });
+    this._form = new SchemaForm(
+      this._context.starter.schema,
+      {
+        liveValidate: true,
+        formData: this._context.body,
+        uiSchema: this._context.starter.uiSchema || {}
+      },
+      { markdown: this.model.manager.markdown }
+    );
+
     this._buttons = this.makeButtons();
 
     this.boxLayout.addWidget(this._form);

--- a/packages/jupyterlab-starters/src/widgets/builder/model.ts
+++ b/packages/jupyterlab-starters/src/widgets/builder/model.ts
@@ -29,6 +29,10 @@ export class BuilderModel extends VDomModel {
     return this._start;
   }
 
+  get manager() {
+    return this._manager;
+  }
+
   get context() {
     return this._context;
   }

--- a/packages/jupyterlab-starters/src/widgets/meta/index.ts
+++ b/packages/jupyterlab-starters/src/widgets/meta/index.ts
@@ -25,23 +25,27 @@ export class NotebookMetadata extends Widget {
     this.addClass(CSS.META);
     this.addClass(CSS.FORM_PANEL);
 
-    this._form = new SchemaForm(this.model.liveSchema, {
-      liveValidate: true,
-      uiSchema: {
-        description: AS_TEXTAREA,
-        icon: AS_TEXTAREA,
-        schema: AS_JSONOBJECT,
-        uiSchema: AS_JSONOBJECT,
-        commands: {
-          items: {
-            args: AS_JSONOBJECT
+    this._form = new SchemaForm(
+      this.model.liveSchema,
+      {
+        liveValidate: true,
+        uiSchema: {
+          description: AS_TEXTAREA,
+          icon: AS_TEXTAREA,
+          schema: AS_JSONOBJECT,
+          uiSchema: AS_JSONOBJECT,
+          commands: {
+            items: {
+              args: AS_JSONOBJECT
+            }
           }
+        },
+        fields: {
+          jsonobject: RawJSONObjectField
         }
       },
-      fields: {
-        jsonobject: RawJSONObjectField
-      }
-    });
+      { markdown: this.model.manager.markdown }
+    );
     this.model.form = this._form.model;
 
     this._preview = new PreviewCard();

--- a/packages/jupyterlab-starters/src/widgets/meta/model.ts
+++ b/packages/jupyterlab-starters/src/widgets/meta/model.ts
@@ -19,12 +19,12 @@ const NOTEBOOK_META_SUBKEY = 'starter';
 export class NotebookMetadataModel extends VDomModel {
   private _form: SchemaFormModel<JSONObject>;
   private _notebook: NotebookPanel;
-  // private _manager: IStarterManager;
+  private _manager: IStarterManager;
   private _commands: CommandRegistry;
 
   constructor(options: NotebookMetadataModel.IOptions) {
     super();
-    // this._manager = options.manager;
+    this._manager = options.manager;
     this._commands = options.commands;
   }
 
@@ -70,6 +70,10 @@ export class NotebookMetadataModel extends VDomModel {
     delete schema['required'];
 
     return schema;
+  }
+
+  get manager() {
+    return this._manager;
   }
 
   get notebook() {

--- a/packages/jupyterlab-starters/src/widgets/rawjson/index.tsx
+++ b/packages/jupyterlab-starters/src/widgets/rawjson/index.tsx
@@ -40,7 +40,7 @@ export class RawJSONObjectField extends ObjectField {
     };
 
     return (
-      <div>
+      <>
         <legend>{title}</legend>
         <p className="field-description">{description}</p>
         <textarea
@@ -49,7 +49,7 @@ export class RawJSONObjectField extends ObjectField {
           defaultValue={JSON.stringify(formData, null, 2)}
           onChange={onChange}
         ></textarea>
-      </div>
+      </>
     );
   }
 }

--- a/packages/jupyterlab-starters/src/widgets/schemaform/index.tsx
+++ b/packages/jupyterlab-starters/src/widgets/schemaform/index.tsx
@@ -3,11 +3,18 @@ import React from 'react';
 import * as rjsf from 'react-jsonschema-form';
 
 import { JSONObject, JSONValue } from '@phosphor/coreutils';
+
 import { VDomRenderer } from '@jupyterlab/apputils';
+
+import { renderMarkdown } from '@jupyterlab/rendermime/lib/renderers';
 
 import { Form } from '../form';
 
 import { SchemaFormModel } from './model';
+
+const MARKDOWN_CLASSES = ['jp-RenderedMarkdown', 'jp-RenderedHTMLCommon'];
+const UNRENDERED_LABELS =
+  'legend:not(.jp-RenderedMarkdown), .field-description:not(.jp-RenderedMarkdown), .control-label:not(.jp-RenderedMarkdown)';
 
 /**
  * The id prefix all JSON Schema forms will share
@@ -28,11 +35,41 @@ export class SchemaForm<T extends JSONValue> extends VDomRenderer<
   /**
    * Construct a new Model
    */
-  constructor(schema: JSONObject, props: Partial<rjsf.FormProps<T>> = {}) {
+  constructor(
+    schema: JSONObject,
+    props: Partial<rjsf.FormProps<T>> = {},
+    options?: SchemaFormModel.IOptions
+  ) {
     super();
     this._idPrefix = `${SCHEMA_FORM_ID_PREFIX}-${Private.nextId()}`;
-    this.model = new SchemaFormModel<T>(schema, props);
+    this.model = new SchemaFormModel<T>(schema, props, options);
+    if (this.model.markdown) {
+      this.model.rendered.connect(this._renderMarkdown);
+    }
   }
+
+  _renderMarkdown = () => {
+    const markdown = this.model.markdown;
+    const hosts = Array.from(this.node.querySelectorAll(UNRENDERED_LABELS));
+    console.log('rendering markdown', hosts);
+    if (!hosts.length) {
+      setTimeout(this._renderMarkdown, 100);
+      return;
+    }
+    for (const host of hosts) {
+      host.classList.add(...MARKDOWN_CLASSES);
+      void renderMarkdown({
+        host: host as HTMLElement,
+        source: host.textContent.trim(),
+        trusted: true,
+        sanitizer: markdown.sanitizer,
+        latexTypesetter: markdown.latexTypesetter,
+        resolver: markdown.resolver,
+        linkHandler: markdown.linkHandler,
+        shouldTypeset: true
+      });
+    }
+  };
 
   /**
    * Render the form, if the model is available
@@ -68,13 +105,14 @@ export class SchemaForm<T extends JSONValue> extends VDomRenderer<
       }
     };
 
-    setTimeout(this._observeErrors, 100);
+    setTimeout(this._postRender, 100);
 
     return <Form {...finalProps} />;
   }
 
-  _observeErrors = () => {
+  private _postRender = () => {
     this.model.errorsObserved = !!this.node.querySelector('.errors');
+    this.model.emitRenderered();
   };
 
   /**

--- a/packages/jupyterlab-starters/src/widgets/schemaform/index.tsx
+++ b/packages/jupyterlab-starters/src/widgets/schemaform/index.tsx
@@ -57,9 +57,9 @@ export class SchemaForm<T extends JSONValue> extends VDomRenderer<
   _renderMarkdown = () => {
     const markdown = this.model.markdown;
     const hosts = Array.from(this.node.querySelectorAll(UNRENDERED_LABELS));
-    console.log('rendering markdown', hosts);
-    if (!hosts.length) {
-      setTimeout(this._renderMarkdown, 100);
+    if (!hosts.length && !this._initialRender) {
+      this._initialRenderDelay = this._initialRenderDelay * 2;
+      setTimeout(this._renderMarkdown, this._initialRenderDelay);
       return;
     }
     for (const host of hosts) {
@@ -75,6 +75,7 @@ export class SchemaForm<T extends JSONValue> extends VDomRenderer<
         shouldTypeset: true
       });
     }
+    this._initialRender = true;
   };
 
   /**
@@ -147,6 +148,8 @@ export class SchemaForm<T extends JSONValue> extends VDomRenderer<
    * The id prefix to use for all form children
    */
   private _idPrefix: string;
+  private _initialRender = false;
+  private _initialRenderDelay = 10;
 }
 
 namespace Private {

--- a/packages/jupyterlab-starters/src/widgets/schemaform/index.tsx
+++ b/packages/jupyterlab-starters/src/widgets/schemaform/index.tsx
@@ -13,8 +13,14 @@ import { Form } from '../form';
 import { SchemaFormModel } from './model';
 
 const MARKDOWN_CLASSES = ['jp-RenderedMarkdown', 'jp-RenderedHTMLCommon'];
-const UNRENDERED_LABELS =
-  'legend:not(.jp-RenderedMarkdown), .field-description:not(.jp-RenderedMarkdown), .control-label:not(.jp-RenderedMarkdown)';
+const UNRENDERED_LABELS = [
+  'legend',
+  '.field-description',
+  '.control-label',
+  '.help-block'
+]
+  .map(s => `${s}:not(.jp-RenderedMarkdown)`)
+  .join(', ');
 
 /**
  * The id prefix all JSON Schema forms will share

--- a/packages/jupyterlab-starters/src/widgets/schemaform/model.ts
+++ b/packages/jupyterlab-starters/src/widgets/schemaform/model.ts
@@ -1,14 +1,23 @@
 import * as rjsf from 'react-jsonschema-form';
 
+import { Signal } from '@phosphor/signaling';
 import { JSONObject, JSONValue } from '@phosphor/coreutils';
 import { VDomModel } from '@jupyterlab/apputils';
+import { RenderedMarkdown } from '@jupyterlab/rendermime';
 
 export class SchemaFormModel<T extends JSONValue> extends VDomModel {
-  constructor(schema: JSONObject, props?: Partial<rjsf.FormProps<T>>) {
+  constructor(
+    schema: JSONObject,
+    props?: Partial<rjsf.FormProps<T>>,
+    options?: SchemaFormModel.IOptions
+  ) {
     super();
     this.schema = schema;
     if (props) {
       this.props = props;
+    }
+    if (options) {
+      this._markdown = options.markdown;
     }
   }
 
@@ -94,9 +103,29 @@ export class SchemaFormModel<T extends JSONValue> extends VDomModel {
     this.stateChanged.emit(void 0);
   }
 
+  get rendered() {
+    return this._rendered;
+  }
+
+  emitRenderered() {
+    this._rendered.emit(void 0);
+  }
+
+  get markdown() {
+    return this._markdown;
+  }
+
   private _formData: T = null;
   private _errors: rjsf.AjvError[] = [];
   private _schema: JSONObject;
   private _props: Partial<rjsf.FormProps<T>>;
   private _errorsObserved = false;
+  private _rendered = new Signal<SchemaFormModel<T>, void>(this);
+  private _markdown: RenderedMarkdown;
+}
+
+export namespace SchemaFormModel {
+  export interface IOptions {
+    markdown?: RenderedMarkdown;
+  }
 }

--- a/packages/jupyterlab-starters/style/form/core.css
+++ b/packages/jupyterlab-starters/style/form/core.css
@@ -47,17 +47,15 @@
   margin-bottom: var(--jp-ui-font-size1);
   width: 100%;
   position: relative;
-  display: flex;
-  flex-direction: column;
 }
 
 .jp-SchemaForm .form-group:last-child {
   margin-bottom: 0;
 }
 
-.jp-SchemaForm .field-description {
+.jp-SchemaForm .field-description,
+.jp-SchemaForm .help-block {
   color: var(--jp-ui-font-color2);
-  order: 2;
 }
 
 .jp-SchemaForm .required {

--- a/packages/jupyterlab-starters/style/form/core.css
+++ b/packages/jupyterlab-starters/style/form/core.css
@@ -20,7 +20,7 @@
 
 .jp-SchemaForm fieldset fieldset {
   padding-left: var(--jp-notebook-padding);
-  border-left: solid 1px var(--jp-border-color0);
+  border-left: solid 4px var(--jp-border-color3);
 }
 
 .jp-SchemaForm button[type='submit'] {
@@ -31,15 +31,24 @@
 .jp-SchemaForm legend {
   margin: 0;
   padding: 0;
-  margin-bottom: calc(var(--jp-ui-font-size1) / 2);
   font-weight: bold;
   display: block;
+  position: relative;
+  display: block;
+}
+
+.jp-SchemaForm .control-label > :first-child,
+.jp-SchemaForm legend > :first-child {
+  margin-top: 0;
+  padding-top: 0;
 }
 
 .jp-SchemaForm .form-group {
   margin-bottom: var(--jp-ui-font-size1);
   width: 100%;
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .jp-SchemaForm .form-group:last-child {
@@ -47,9 +56,8 @@
 }
 
 .jp-SchemaForm .field-description {
-  font-style: italic;
-  margin-bottom: calc(var(--jp-ui-font-size1) / 2);
   color: var(--jp-ui-font-color2);
+  order: 2;
 }
 
 .jp-SchemaForm .required {
@@ -57,6 +65,7 @@
   color: var(--jp-warn-color1);
   font-weight: 800;
   position: absolute;
-  margin-left: 0.1em;
-  margin-top: -0.1em;
+  top: 0;
+  right: 0;
+  display: block;
 }

--- a/packages/jupyterlab-starters/style/index.css
+++ b/packages/jupyterlab-starters/style/index.css
@@ -34,7 +34,7 @@
 }
 
 .jp-Starters-NotebookMetadata {
-  min-width: 300px;
+  min-width: 350px;
 }
 
 .jp-Starters-BodyBuilder-buttons {
@@ -81,4 +81,8 @@
 
 .jp-Starters-FormPanel .jp-SchemaForm > .form-group {
   margin-bottom: 20rem;
+}
+
+.jp-Starters-FormPanel .jp-RenderedHTMLCommon {
+  padding: 0;
 }

--- a/src/jupyter_starters/schema/v2.json
+++ b/src/jupyter_starters/schema/v2.json
@@ -107,12 +107,12 @@
         },
         "icon": {
           "title": "Icon",
-          "description": "an SVG to use in Launcher cards and tab icons",
+          "description": "[SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) string to use in Launcher cards and tab icons",
           "type": "string"
         },
         "commands": {
           "title": "Commands",
-          "description": "JupyterLab commands to run after the Starter has completed",
+          "description": "[JupyterLab commands](https://jupyterlab.readthedocs.io/en/stable/developer/extension_points.html#commands) to run after the Starter has completed",
           "type": "array",
           "items": {
             "$ref": "#/definitions/command"
@@ -120,7 +120,7 @@
         },
         "ignore": {
           "title": "Ignore Files",
-          "description": "Folders and files exclude from copying, with * for wildcards",
+          "description": "[glob-style patterns](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.match) for folders and files exclude from copying, with * for wildcards",
           "type": "array",
           "items": {
             "type": "string"
@@ -128,20 +128,19 @@
         },
         "schema": {
           "title": "JSON Schema",
-          "description": "JSON schema the body must validate against before continuing",
+          "description": "[Draft 7 JSON Schema](https://json-schema.org/understanding-json-schema) that generates a form like this one, which must validate the user's data. Description fields may include markdown",
           "type": "object",
           "$ref": "#/definitions/json-schema"
         },
         "uiSchema": {
           "title": "UI Schema",
-          "description": "A react-jsonschema-form UI schema for customizing the selection of widgets https://react-jsonschema-form.readthedocs.io/en/latest/form-customization/#the-uischema-object",
+          "description": "[react-jsonschema-form `uiSchema`](https://react-jsonschema-form.readthedocs.io/en/latest/form-customization/#the-uischema-object) for customizing the selection of widgets",
           "type": "object"
         }
       }
     },
     "json-schema": {
       "title": "JSON Schema",
-      "description": "presently under-defined because of toolchain",
       "type": "object"
     },
     "command": {


### PR DESCRIPTION
## References

- fixes #11 
- closes #16, as the approach was infeasible:
  - some parts of rjsf (e.g. `Label`) were not trivially overrideable
    - perhaps in the future, this will work
  - inline `unsafelySetInnerHTMLDANGERDANGER` approach didn't play nicely with math typesetting, syntax highlighting

## Code changes

Uses a dummy `RendererdMarkdown` to update all `description`s and `title`s after rendering.

## User-facing changes

Starter builders can include custom Jupyter Markdown inside their forms.

## Backwards-incompatible changes

If you were using plain text that looks like markdown (or mathjax) it will start rendering it (weirdly).

## Chores

- [x] linted
- [x] tested
- [x] documented
- [x] changelog entry
