### PR TITLE
add router integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#29][] some updated class names based on schema
 - [#34][] add stauts indicator for starting/continuing
+- [#35][] add `/lab/tree/starter/<starter>/<path>` URL router
 
 ## `jupyter_starters 0.2.1a0`
 
@@ -64,3 +65,4 @@
 [#25]: https://github.com/deathbeds/jupyterlab-starters/pull/25
 [#29]: https://github.com/deathbeds/jupyterlab-starters/pull/29
 [#34]: https://github.com/deathbeds/jupyterlab-starters/pull/34
+[#35]: https://github.com/deathbeds/jupyterlab-starters/pull/35

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, dead pixels collective
+Copyright (c) 2020, dead pixels collective
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,7 @@
 # ROADMAP
 
-- [ ] Do a release
 - [ ] Adopt some well-known locations for more user-serviceable starters
 - [ ] Add generic `script` type
-- [ ] More documentation
 - [ ] Add preview/dry-run
 - [ ] Add better error handling and logging
 - [ ] Explore [json-e](https://github.com/taskcluster/json-e) integration

--- a/atest/08_Tree_URL.robot
+++ b/atest/08_Tree_URL.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Documentation     Tree URL
+Suite Setup       Setup Suite For Screenshots    tree-url
+Force Tags        example:tree-url
+Resource          Keywords.robot
+Library           String
+
+*** Test Cases ***
+Starter Opens
+    [Documentation]    Does a URL-provided starter open?
+    Go To    ${URL}lab/tree/starter/cookiecutter/examples
+    Wait For Splash
+    ${template css} =    Set Variable    css:input[label\="Template"]
+    Wait Until Page Contains Element    ${template css}    timeout=10s
+    Capture Page Screenshot    00-tree-url-did-launch.png

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -40,11 +40,11 @@ h6 code {
 }
 
 h1 {
-  font-size: 350%;
+  font-size: 250%;
 }
 
 h2 {
-  font-size: 200%;
+  font-size: 150%;
 }
 
 p {
@@ -96,10 +96,12 @@ a:active {
 .rst-content .section:not(#all-json-schema) .toctree-wrapper > ul {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .rst-content .section:not(#all-json-schema) .toctree-wrapper > ul > li {
   flex: 1;
+  margin-bottom: 1em;
 }
 
 .rst-content .section:not(#all-json-schema) .toctree-wrapper ul,
@@ -107,6 +109,7 @@ a:active {
   list-style: none;
   margin: 0;
   padding: 0;
+  min-width: 300px;
 }
 
 .rst-content .section:not(#all-json-schema) .toctree-wrapper .toctree-l1 > a {

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -72,6 +72,7 @@ iframe {
 
 a {
   border-bottom: solid var(--border-width) transparent;
+  color: var(--deathbeds);
 }
 
 a:hover,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ sys.path.insert(0, str((pathlib.Path.cwd().parent / "src").resolve()))
 # -- Project information -----------------------------------------------------
 
 project = "JupyterStarters"
-copyright = "2019, Dead Pixels Collective"
+copyright = "2020, Dead Pixels Collective"
 author = "Deathbeds"
 
 # The short X.Y version

--- a/docs/notebooks/History.ipynb
+++ b/docs/notebooks/History.ipynb
@@ -43,6 +43,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Roadmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "IPython.display.Markdown(\n",
+    "    \"\\n\".join((HERE / \"..\" / \"..\" / \"ROADMAP.md\").read_text().splitlines()[1:])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### License"
    ]
   },

--- a/docs/notebooks/Starters.ipynb
+++ b/docs/notebooks/Starters.ipynb
@@ -32,6 +32,7 @@
     "> - advertise to JupyterLab via the [REST API](./REST%20API.ipynb)\n",
     "> - display in the _JupyterLab Launcher_\n",
     "> - **click a button** in the _JupyterLab Launcher_\n",
+    ">   - or immediately start with a [Starter Tree URL](#Starter-Tree-URL)\n",
     "> - zero or more (but usually one) times: \n",
     ">   - gather more information from the user via [react-jsonschema-form](https://react-jsonschema-form.readthedocs.io)\n",
     ">   - perform further processing\n",
@@ -306,6 +307,37 @@
    "metadata": {},
    "source": [
     "Under the hood, the cookiecutter starter is implemented as a [Python starter](#Python), and can be seen as tutorial in how to create a starter from a complex piece of existing functionality."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extras"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Starter Tree URL\n",
+    "\n",
+    "By specifying a special URL when starting JupyterLab, you can immediately start a Starter, without requiring the launcher. The pattern is:\n",
+    "\n",
+    "```\n",
+    "{:protocol}://{:host}:{:port}{:base-url}/lab/tree/starter/{:starter-name}{:starter-path}\n",
+    "```\n",
+    "\n",
+    "For example:\n",
+    "```\n",
+    "http://localhost:8888/lab/tree/starter/cookiecutter\n",
+    "```\n",
+    "\n",
+    "On [Binder](https://mybinder.org), this path is determined by the `urlpath` `GET` parameter, for example:\n",
+    "\n",
+    "```\n",
+    "https://mybinder.org/v2/gh/deathbeds/jupyterlab-starters/master?urlpath=lab%2Ftree%2Fcookiecutter%2Fexamples\n",
+    "```"
    ]
   }
  ],

--- a/docs/notebooks/Use Cases.ipynb
+++ b/docs/notebooks/Use Cases.ipynb
@@ -12,6 +12,7 @@
    "metadata": {},
    "source": [
     "### The Demo\n",
+    "\n",
     "> I built a cool [Binder](https://mybinder.org) (and even included `?urlpath=lab/tree/tutorial.ipynb` to open a notebook) to showcase my library, but when visitors get to their Binder, they still have to _read a notebook_ and `shift+enter` their way through my example to see the plot at the end.\n",
     "\n",
     "A starter can _increase engagement_ by:\n",
@@ -26,9 +27,11 @@
    "metadata": {},
    "source": [
     "### The Chore\n",
+    "\n",
     "> When my scientists start a new experiment they hope will become reproducible research, they start a new folder that contains a notebook, a spreadsheet and a few other artifacts. Sometimes they don't do it... quite right.\n",
     "\n",
     "A starter can _enhance reproducibility_ by:\n",
+    "\n",
     "- automating boring chores\n",
     "- standardizing file names"
    ]

--- a/docs/notebooks/Use Cases.ipynb
+++ b/docs/notebooks/Use Cases.ipynb
@@ -17,7 +17,8 @@
     "A starter can _increase engagement_ by:\n",
     "\n",
     "- creating personalized content\n",
-    "- running [JupyterLab commands](https://jupyterlab.readthedocs.io/en/stable/user/commands.html) on the users behalf, including the mighty `Run All Cells`"
+    "- running [JupyterLab commands](https://jupyterlab.readthedocs.io/en/stable/user/commands.html) on the users behalf, including the mighty `Run All Cells`\n",
+    "- launching a starter directly, with a [Starter Tree URL](./Starters.ipynb#Starter%20Tree%20URL)"
    ]
   },
   {

--- a/examples/whitepaper-multiple/00 Introduction.ipynb
+++ b/examples/whitepaper-multiple/00 Introduction.ipynb
@@ -10,14 +10,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import IPython, pathlib, urllib.parse\n",
+    "\n",
+    "# generate a little table of contents\n",
     "IPython.display.Markdown(\"\".join([f\"\"\"\n",
     "- [{path.name[3:-6]}](./{urllib.parse.quote(path.name)})\"\"\"\n",
     "for path in sorted(pathlib.Path().glob(\"*.ipynb\"))]))"

--- a/examples/whitepaper-multiple/10 What are you trying to do.ipynb
+++ b/examples/whitepaper-multiple/10 What are you trying to do.ipynb
@@ -6,6 +6,13 @@
    "source": [
     "### What are you trying to do? Articulate your objectives using absolutely no jargon."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "..."
+   ]
   }
  ],
  "metadata": {

--- a/examples/whitepaper-multiple/20 How is it done today.ipynb
+++ b/examples/whitepaper-multiple/20 How is it done today.ipynb
@@ -6,6 +6,11 @@
    "source": [
     "### How is it done today, and what are the limits of current practice?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
@@ -24,7 +29,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/whitepaper-multiple/30 What is new in your approach.ipynb
+++ b/examples/whitepaper-multiple/30 What is new in your approach.ipynb
@@ -6,6 +6,11 @@
    "source": [
     "### What is new in your approach and why do you think it will be successful?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
@@ -24,7 +29,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/whitepaper-multiple/40 Who cares.ipynb
+++ b/examples/whitepaper-multiple/40 Who cares.ipynb
@@ -6,6 +6,11 @@
    "source": [
     "### Who cares? If you are successful, what difference will it make?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/whitepaper-multiple/50 What are the risks.ipynb
+++ b/examples/whitepaper-multiple/50 What are the risks.ipynb
@@ -6,6 +6,11 @@
    "source": [
     "### What are the risks?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
@@ -24,7 +29,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/whitepaper-multiple/60 How much will it cost.ipynb
+++ b/examples/whitepaper-multiple/60 How much will it cost.ipynb
@@ -6,6 +6,11 @@
    "source": [
     "### How much will it cost?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
@@ -24,7 +29,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/whitepaper-multiple/70 How long will it take.ipynb
+++ b/examples/whitepaper-multiple/70 How long will it take.ipynb
@@ -6,6 +6,11 @@
    "source": [
     "### How long will it take?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
@@ -24,7 +29,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/whitepaper-multiple/80 What are the mid-term and final exams.ipynb
+++ b/examples/whitepaper-multiple/80 What are the mid-term and final exams.ipynb
@@ -6,6 +6,11 @@
    "source": [
     "### What are the mid-term and final “exams” to check for success?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
@@ -24,7 +29,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/whitepaper-single.ipynb
+++ b/examples/whitepaper-single.ipynb
@@ -105,6 +105,11 @@
    "source": [
     "### What are the mid-term and final “exams” to check for success?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/packages/jupyterlab-starters/LICENSE
+++ b/packages/jupyterlab-starters/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, dead pixels collective
+Copyright (c) 2020, dead pixels collective
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/packages/jupyterlab-starters/src/css.ts
+++ b/packages/jupyterlab-starters/src/css.ts
@@ -2,6 +2,9 @@ import DEFAULT_ICON_SVG from '!!raw-loader!../style/icons/starter.svg';
 import COOKIECUTTER_SVG from '!!raw-loader!../style/icons/cookiecutter.svg';
 
 export const CSS = {
+  P: {
+    hidden: 'p-mod-hidden'
+  },
   JP: {
     accept: 'jp-mod-accept',
     reject: 'jp-mod-reject',

--- a/packages/jupyterlab-starters/src/manager.ts
+++ b/packages/jupyterlab-starters/src/manager.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from '@phosphor/coreutils';
+import { JSONObject, PromiseDelegate } from '@phosphor/coreutils';
 import { Signal } from '@phosphor/signaling';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
@@ -24,6 +24,7 @@ export class StarterManager implements IStarterManager {
   private _icons: IIconRegistry;
   private _rendermime: IRenderMimeRegistry;
   private _markdown: RenderedMarkdown;
+  private _ready = new PromiseDelegate<void>();
 
   constructor(options: IStarterManager.IOptions) {
     this._icons = options.icons;
@@ -46,6 +47,10 @@ export class StarterManager implements IStarterManager {
     return this._markdown;
   }
 
+  get ready() {
+    return this._ready.promise;
+  }
+
   get changed() {
     return this._changed;
   }
@@ -63,6 +68,7 @@ export class StarterManager implements IStarterManager {
     const content = (await response.json()) as SCHEMA.AResponseForAnStartersRequest;
     this._starters = content.starters;
     this._changed.emit(void 0);
+    this._ready.resolve(void 0);
   }
 
   async start(

--- a/packages/jupyterlab-starters/src/plugin.ts
+++ b/packages/jupyterlab-starters/src/plugin.ts
@@ -1,8 +1,11 @@
+import { URLExt } from '@jupyterlab/coreutils';
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
-  ILabShell
+  ILabShell,
+  IRouter
 } from '@jupyterlab/application';
+
 import { ILauncher } from '@jupyterlab/launcher';
 import { IIconRegistry } from '@jupyterlab/ui-components';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
@@ -23,6 +26,7 @@ import {
 } from './tokens';
 import { NotebookStarter } from './notebookbutton';
 import * as SCHEMA from './_schema';
+import { CSS } from './css';
 
 import { NotebookMetadata } from './widgets/meta';
 import { BodyBuilder } from './widgets/builder';
@@ -30,20 +34,24 @@ import { BodyBuilder } from './widgets/builder';
 const plugin: JupyterFrontEndPlugin<void> = {
   id: `${NS}:plugin`,
   requires: [
+    JupyterFrontEnd.IPaths,
     ILabShell,
     ILauncher,
     IIconRegistry,
     INotebookTracker,
-    IRenderMimeRegistry
+    IRenderMimeRegistry,
+    IRouter
   ],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
+    paths: JupyterFrontEnd.IPaths,
     shell: ILabShell,
     launcher: ILauncher,
     icons: IIconRegistry,
     notebooks: INotebookTracker,
-    rendermime: IRenderMimeRegistry
+    rendermime: IRenderMimeRegistry,
+    router: IRouter
   ) => {
     const { commands } = app;
     const manager: IStarterManager = new StarterManager({ icons, rendermime });
@@ -154,6 +162,72 @@ const plugin: JupyterFrontEndPlugin<void> = {
         )} as Starter`;
       },
       iconClass: DEFAULT_ICON_CLASS
+    });
+
+    const starterPattern = new RegExp(
+      `^${paths.urls.tree}/starter/([^/]+)/?(.*)`
+    );
+
+    commands.addCommand(CommandIDs.routerStart, {
+      execute: async args => {
+        const loc = args as IRouter.ILocation;
+        const starterMatch = loc.path.match(starterPattern);
+        if (starterMatch == null) {
+          return;
+        }
+        const [name, cwd] = starterMatch.slice(1);
+
+        await manager.ready;
+
+        const starter = manager.starters[name];
+
+        if (starter == null) {
+          return;
+        }
+
+        const url = URLExt.join(paths.urls.tree, cwd);
+
+        router.navigate(url);
+
+        void commands.execute(CommandIDs.start, {
+          name,
+          cwd,
+          starter
+        });
+
+        let notHiddenCount = 0;
+        const contentId = `id-jp-starters-${name}`;
+
+        const expandInterval = setInterval(() => {
+          const hidden = document.querySelector(
+            `#jp-right-stack.${CSS.P.hidden}`
+          );
+          if (hidden) {
+            shell.expandRight();
+            shell.activateById(contentId);
+            return;
+          }
+          const sidebar = document.querySelector(
+            `.${CSS.BUILDER}:not(.${CSS.P.hidden})`
+          );
+          if (sidebar) {
+            notHiddenCount++;
+            shell.expandRight();
+            shell.activateById(contentId);
+            if (notHiddenCount > 3) {
+              clearInterval(expandInterval);
+            }
+          }
+        }, 100);
+
+        return router.stop;
+      }
+    });
+
+    router.register({
+      command: CommandIDs.routerStart,
+      pattern: starterPattern,
+      rank: 29
     });
 
     const notebookbutton = new NotebookStarter({ commands });

--- a/packages/jupyterlab-starters/src/plugin.ts
+++ b/packages/jupyterlab-starters/src/plugin.ts
@@ -195,30 +195,36 @@ const plugin: JupyterFrontEndPlugin<void> = {
           starter
         });
 
-        let notHiddenCount = 0;
-        const contentId = `id-jp-starters-${name}`;
+        if (starter.schema) {
+          let notHiddenCount = 0;
+          let retries = 20;
+          const contentId = `id-jp-starters-${name}`;
 
-        const expandInterval = setInterval(() => {
-          const hidden = document.querySelector(
-            `#jp-right-stack.${CSS.P.hidden}`
-          );
-          if (hidden) {
-            shell.expandRight();
-            shell.activateById(contentId);
-            return;
-          }
-          const sidebar = document.querySelector(
-            `.${CSS.BUILDER}:not(.${CSS.P.hidden})`
-          );
-          if (sidebar) {
-            notHiddenCount++;
-            shell.expandRight();
-            shell.activateById(contentId);
-            if (notHiddenCount > 3) {
+          const expandInterval = setInterval(() => {
+            if (retries-- <= 0) {
               clearInterval(expandInterval);
             }
-          }
-        }, 100);
+            const hidden = document.querySelector(
+              `#jp-right-stack.${CSS.P.hidden}`
+            );
+            if (hidden) {
+              shell.expandRight();
+              shell.activateById(contentId);
+              return;
+            }
+            const sidebar = document.querySelector(
+              `.${CSS.BUILDER}:not(.${CSS.P.hidden})`
+            );
+            if (sidebar) {
+              notHiddenCount++;
+              shell.expandRight();
+              shell.activateById(contentId);
+              if (notHiddenCount > 3) {
+                clearInterval(expandInterval);
+              }
+            }
+          }, 500);
+        }
 
         return router.stop;
       }

--- a/packages/jupyterlab-starters/src/tokens.ts
+++ b/packages/jupyterlab-starters/src/tokens.ts
@@ -23,6 +23,7 @@ export interface IStarterManager {
   icons: IIconRegistry;
   markdown: RenderedMarkdown;
   fetch(): Promise<void>;
+  ready: Promise<void>;
   start(
     name: string,
     starter: SCHEMA.Starter,
@@ -40,6 +41,7 @@ export namespace IStarterManager {
 
 export namespace CommandIDs {
   export const start = `${NS}:start`;
+  export const routerStart = `${NS}:router-starter`;
   export const notebookMeta = `${NS}:notebook-meta`;
 }
 

--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -58,11 +58,15 @@ HTML_REPLACEMENTS = [
 
 SKIPS = "not github and not ujson"
 
+SCHEMA_README = SCHEMA_DOCS / "README.md"
+
 
 def fix_schema_md():
     """ fix up generated markdown to work (somewhat better) with sphinx
     """
-    (SCHEMA_DOCS / "README.md").unlink()
+    if SCHEMA_README.exists():
+        SCHEMA_README.unlink()
+
     md_files = list(SCHEMA_DOCS.glob("*.md"))
 
     check_call(["jlpm", "prettier", "--write", "--loglevel", "silent", *md_files])
@@ -113,7 +117,7 @@ def docs():
         shutil.rmtree(SCHEMA_DOCS, ignore_errors=1)
         check_call(["sphinx-build", "-M", "html", DOCS, DOCS_BUILD])
         check_call(["pytest", "--check-links", DOCS_BUILD, "-k", SKIPS])
-    elif SETUP:
+    elif SETUP and not SCHEMA_DOCS.exists():
         check_call(["jlpm"])
         check_call(
             [

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -48,7 +48,9 @@ def nblint():
                     cell.execution_count = None
                     changed = True
 
-        if not nbf.cells[-1].source.strip():
+        last_cell = nbf.cells[-1]
+
+        if last_cell.cell_type == "code" and not last_cell.source.strip():
             nbf.cells = nbf.cells[:-1]
             changed = True
 

--- a/src/jupyter_starters/py_starters/cookiecutter.py
+++ b/src/jupyter_starters/py_starters/cookiecutter.py
@@ -80,6 +80,7 @@ def cookiecutter_starters(manager):
             "type": "python",
             "callable": "jupyter_starters.py_starters.cookiecutter.start",
             "schema": {
+                "type": "object",
                 "required": ["template"],
                 "properties": {
                     "template": {

--- a/src/jupyter_starters/py_starters/cookiecutter.py
+++ b/src/jupyter_starters/py_starters/cookiecutter.py
@@ -103,7 +103,10 @@ def cookiecutter_starters(manager):
                     },
                 },
             },
-            "uiSchema": {"checkout": {"ui:placeholder": "master"}},
+            "uiSchema": {
+                "template": {"ui:autofocus": True},
+                "checkout": {"ui:placeholder": "master"},
+            },
         }
     }
 


### PR DESCRIPTION
## Binder

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bollwyvl/jupyterlab-starters/add-url-router?urlpath=lab%2Ftree%2Fstarter%2Fcookiecutter%2Fexamples)

> this is a pretty decent test

## References

- fixes #35 

## Code changes

Adds a new route (powered by a command) which can open a starter from just the `name` and the `cwd`.

## User-facing changes

Allows zero-click starter _launching_, and tries to open the form.

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [x] documented
- [x] changelog entry
