### PR TITLE
Addition of category and rank as starter props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+
+## `jupyter_starters 1.1.0f1`
+
+- [] add category and rank for placement of the starters in the launcher.
+
 ## `jupyter_starters 1.1.0`
 
 - [#62] adds a CLI tool, `jupyter starters list` (with option `--json`)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ launched from in the JupyterLab [Launcher][].
         "type": "copy",
         "label": "Whitepaper Notebook",
         "description": "A reusable notebook for proposing research",
+        "category": "Notebook starters",
+        "rank": 0,
         "src": "examples/whitepaper-single.ipynb"
       }
     }

--- a/dodo.py
+++ b/dodo.py
@@ -726,8 +726,8 @@ class P:
     YARN_INTEGRITY = NODE_MODULES / ".yarn-integrity"
     DIST = ROOT / "dist"
     # TODO: single-source version
-    PY_VERSION = "1.1.0"
-    JS_VERSION = "1.1.0"
+    PY_VERSION = "1.1.0f1"
+    JS_VERSION = "1.1.0f1"
     SDIST = DIST / f"jupyter_starters-{PY_VERSION}.tar.gz"
     WHEEL = DIST / f"jupyter_starters-{PY_VERSION}-py3-none-any.whl"
     NPM_TARBALLS = {

--- a/jupyter_notebook_config.json
+++ b/jupyter_notebook_config.json
@@ -8,24 +8,28 @@
         "type": "notebook",
         "src": "./examples/Starter Notebook.ipynb",
         "label": "Starter Notebook",
-        "description": "A notebook that is also a starter"
+        "description": "A notebook that is also a starter",
+        "category": "Notebooks"
       },
       "multi-stage-notebook": {
         "type": "notebook",
         "src": "./examples/Multi-Stage Starter Notebook.ipynb",
         "label": "Multi-Stage Starter Notebook",
-        "description": "Build a directory one file at a time"
+        "description": "Build a directory one file at a time",
+        "category": "Notebooks"
       },
       "whitepaper-single": {
         "type": "copy",
         "label": "Whitepaper Notebook",
         "description": "A reusable notebook for proposing research",
+        "category": "Notebooks",
         "src": "examples/whitepaper-single.ipynb"
       },
       "whitepaper-multiple": {
         "type": "copy",
         "label": "Whitepaper Folder",
         "description": "Some reusable notebooks for proposing research",
+        "category": "Notebooks",
         "icon": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'><g class='jp-icon-contrast1' fill='#ccc'><circle cx='24' cy='24' r='24'/></g></svg>",
         "src": "examples/whitepaper-multiple"
       },
@@ -33,6 +37,7 @@
         "type": "copy",
         "label": "Named Whitepaper",
         "description": "A renamed whitepaper",
+        "category": "Notebooks",
         "src": "examples/whitepaper-single.ipynb",
         "dest": "{% now 'local' %} {{ dest }} Whitepaper.ipynb",
         "icon": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><g class='jp-icon-contrast3' fill='#ccc'><rect width='100' height='100'/></g></svg>",

--- a/jupyter_server_config.json
+++ b/jupyter_server_config.json
@@ -7,32 +7,40 @@
       "notebook-starter": {
         "type": "notebook",
         "src": "./examples/Starter Notebook.ipynb",
-        "label": "Starter Notebook",
-        "description": "A notebook that is also a starter"
+        "label": "ABC Starter Notebook",
+        "description": "A notebook that is also a starter",
+        "category": "Notebooks"
       },
       "multi-stage-notebook": {
         "type": "notebook",
         "src": "./examples/Multi-Stage Starter Notebook.ipynb",
-        "label": "Multi-Stage Starter Notebook",
-        "description": "Build a directory one file at a time"
+        "label": "ABC Multi-Stage Starter Notebook",
+        "description": "Build a directory one file at a time",
+        "category": "Notebooks"
       },
       "whitepaper-single": {
         "type": "copy",
-        "label": "Whitepaper Notebook",
+        "label": "ABC Whitepaper Notebook",
+        "rank": 1,
         "description": "A reusable notebook for proposing research",
-        "src": "examples/whitepaper-single.ipynb"
+        "src": "examples/whitepaper-single.ipynb",
+        "category": "Notebooks"
       },
       "whitepaper-multiple": {
         "type": "copy",
-        "label": "Whitepaper Folder",
+        "label": "ABC Whitepaper Folder",
         "description": "Some reusable notebooks for proposing research",
+        "category": "Notebooks",
+        "rank": 2,
         "icon": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'><g class='jp-icon-contrast1' fill='#ccc'><circle cx='24' cy='24' r='24'/></g></svg>",
         "src": "examples/whitepaper-multiple"
       },
       "whitepaper-named": {
         "type": "copy",
-        "label": "Named Whitepaper",
+        "label": "ABC Named Whitepaper",
         "description": "A renamed whitepaper",
+        "category": "Notebooks",
+        "rank": 3,
         "src": "examples/whitepaper-single.ipynb",
         "dest": "{% now 'local' %} {{ dest }} Whitepaper.ipynb",
         "icon": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><g class='jp-icon-contrast3' fill='#ccc'><rect width='100' height='100'/></g></svg>",

--- a/packages/jupyterlab-starters/src/plugin.ts
+++ b/packages/jupyterlab-starters/src/plugin.ts
@@ -22,6 +22,7 @@ import {
   NS,
   CommandIDs,
   CATEGORY,
+  RANK,
   IStartContext,
   IStarterManager,
   DEFAULT_ICON_CLASS,
@@ -249,7 +250,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
         launcher.add({
           command: CommandIDs.start,
           args: { name, starter: starters[name] },
-          category: CATEGORY,
+          category: starters[name].category || CATEGORY,
+          rank: starters[name].rank || RANK
         });
         cardsAdded.push(name);
       }

--- a/packages/jupyterlab-starters/src/tokens.ts
+++ b/packages/jupyterlab-starters/src/tokens.ts
@@ -14,6 +14,7 @@ export const API = URLExt.join(PageConfig.getBaseUrl(), 'starters');
 export const DEFAULT_ICON_NAME = `${NS}:default`;
 export const DEFAULT_ICON_CLASS = `jp-StartersDefaultIcon`;
 export const CATEGORY = 'Starters';
+export const RANK = Infinity;
 
 export interface IStarterManager extends IRunningSessions.IManager {
   changed: ISignal<IStarterManager, void>;

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,4 @@
+jlpm
+jlpm run build
+pip install . --upgrade
+jupyter lab

--- a/src/jupyter_starters/_version.py
+++ b/src/jupyter_starters/_version.py
@@ -1,3 +1,3 @@
 """ single source of truth for jupyter_starters version
 """
-__version__ = "1.1.0"
+__version__ = "1.1.0f1"

--- a/src/jupyter_starters/schema/v2.json
+++ b/src/jupyter_starters/schema/v2.json
@@ -146,6 +146,16 @@
           "description": "[SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) string to use in Launcher cards and tab icons",
           "type": "string"
         },
+        "category": {
+          "title": "Category",
+          "description": "Category to place the starter card under in Launcher",
+          "type": "string"
+        },
+        "rank": {
+          "title": "Rank",
+          "description": "Rank of the launcher card within the category",
+          "type": "integer"
+        },
         "commands": {
           "title": "Commands",
           "description": "[JupyterLab commands](https://jupyterlab.readthedocs.io/en/stable/developer/extension_points.html#commands) to run after the Starter has completed",


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-starters!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/deathbeds/jupyterlab-starters/blob/master/CONTRIBUTING.md
-->

## References

Issue #75 

## Code changes

Added two properties to the schema:

- `category`: category of the starter that becomes the header of the group in the launcher: defaults to `Starters`
- `rank`: control over the order of the starters in a certain category: defaults to Infinity


## User-facing changes

Change is backwards compatible, but if category is given, then multiple headers are created in the launcher.

If rank is given, then the starters are sorted accordingly within the category.

## Backwards-incompatible changes

N/A

## Chores

- [ ] linted
- [ ] tested
- [ ] checked on binder
- [ ] documented
- [ ] changelog entry
